### PR TITLE
Investigate booking submission failure

### DIFF
--- a/happymop/src/main/resources/static/Bookslot.html
+++ b/happymop/src/main/resources/static/Bookslot.html
@@ -119,8 +119,8 @@
 
 <script>
     // services will be fetched from backend /api/services
-    // API_BASE chooses the backend host: when the page is opened via file:// we fallback to localhost:8080
-    const API_BASE = (window.location.protocol === 'file:' || window.location.origin === 'null') ? 'http://localhost:8080' : window.location.origin;
+    // API_BASE chooses the backend host: when the page is opened via file:// we fallback to localhost:8081 (matches Spring Boot dev port)
+    const API_BASE = (window.location.protocol === 'file:' || window.location.origin === 'null') ? 'http://localhost:8081' : window.location.origin;
     let services = [];
     let lastServiceError = null;
     let cart = []; // array of service codes/ids


### PR DESCRIPTION
Update the fallback API base port in `Bookslot.html` to match the Spring Boot dev server port (8081).

The frontend was attempting to submit booking requests to `http://localhost:8080` when opened via `file://`, while the backend was listening on `http://localhost:8081`, causing the "Failed to submit booking" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1720cbf-c1ed-44c6-ba01-870d8af837dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1720cbf-c1ed-44c6-ba01-870d8af837dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

